### PR TITLE
calling default lambda only once per delegate

### DIFF
--- a/src/main/kotlin/com/xenomachina/argparser/Default.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/Default.kt
@@ -39,14 +39,14 @@ fun <T> ArgParser.DelegateProvider<T>.default(newDefault: () -> T): ArgParser.De
 /**
  * Returns a new `Delegate` with the specified default value.
  *
- * @param newDefault the default value for the resulting [ArgParser.Delegate]
+ * @param defaultValue the default value for the resulting [ArgParser.Delegate]
  */
 fun <T> ArgParser.Delegate<T>.default(defaultValue: T): ArgParser.Delegate<T> = default { defaultValue }
 
 /**
  * Returns a new `Delegate` with the specified default value as a lambda.
  *
- * @param newDefault the default value for the resulting [ArgParser.Delegate]
+ * @param defaultValue the default value for the resulting [ArgParser.Delegate]
  */
 fun <T> ArgParser.Delegate<T>.default(defaultValue: () -> T): ArgParser.Delegate<T> {
     if (hasValidators) {
@@ -55,6 +55,8 @@ fun <T> ArgParser.Delegate<T>.default(defaultValue: () -> T): ArgParser.Delegate
     val inner = this
 
     return object : ArgParser.Delegate<T>() {
+
+        private val computedDefault by lazy(defaultValue)
 
         override val hasValidators: Boolean
             get() = inner.hasValidators
@@ -71,7 +73,7 @@ fun <T> ArgParser.Delegate<T>.default(defaultValue: () -> T): ArgParser.Delegate
         override val value: T
             get() {
                 inner.parser.force()
-                return if (inner.hasValue) inner.value else defaultValue()
+                return if (inner.hasValue) inner.value else computedDefault
             }
 
         override val hasValue: Boolean

--- a/src/test/kotlin/com/xenomachina/argparser/DefaultTest.kt
+++ b/src/test/kotlin/com/xenomachina/argparser/DefaultTest.kt
@@ -1,0 +1,38 @@
+// Copyright © 2018 Tobias Berger
+//
+// This file is part of kotlin-argparser, a library which can be found at
+// http://github.com/xenomachina/kotlin-argparser
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by the
+// Free Software Foundation; either version 2.1 of the License, or (at your
+// option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, see http://www.gnu.org/licenses/
+
+package com.xenomachina.argparser
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+
+class DefaultTest : FunSpec({
+    test("Single call on default lambda") {
+        val parser = parserOf()
+
+        var callCount = 0
+        val testDelegate by parser.storing("-t") { toInt() }
+                .default { ++callCount }
+
+        callCount shouldBe 0
+        testDelegate shouldBe 1
+        callCount shouldBe 1
+        testDelegate shouldBe 1
+        callCount shouldBe 1
+    }
+})


### PR DESCRIPTION
When using a missing argument multiple times, the lambda that provides a default value was called at every use of the delegate. In some cases, like asking the user to input the value on command line, this behaviour can be undesirable.