### PR TITLE
Added --version option in the same manner as --help.

### DIFF
--- a/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
@@ -38,7 +38,8 @@ import kotlin.reflect.KProperty
 class ArgParser(
     args: Array<out String>,
     mode: Mode = Mode.GNU,
-    helpFormatter: HelpFormatter? = DefaultHelpFormatter()
+    helpFormatter: HelpFormatter? = DefaultHelpFormatter(),
+    version: String? = null
 ) {
 
     enum class Mode {
@@ -617,6 +618,13 @@ class ArgParser(
                     errorName = "HELP", // This should never be used, but we need to say something
                     help = "show this help message and exit") {
                 throw ShowHelpException(helpFormatter, delegates.toList())
+            }.default(Unit).registerRoot()
+        }
+        if (version != null) {
+            option<Unit>("-v", "--version",
+                    errorName = "VERSION", // This should never be used, but we need to say something
+                    help = "show the version and exit") {
+                throw ShowVersionException(version)
             }.default(Unit).registerRoot()
         }
     }

--- a/src/main/kotlin/com/xenomachina/argparser/Exceptions.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/Exceptions.kt
@@ -34,6 +34,18 @@ class ShowHelpException internal constructor(
 }
 
 /**
+ * Indicates that the user requested that the version should be shown (with the
+ * `--version` option, for example).
+ */
+class ShowVersionException internal constructor(
+    private val version: String
+) : SystemExitException("version was requested", 0) {
+    override fun printUserMessage(writer: Writer, programName: String?, columns: Int) {
+        writer.write(version)
+    }
+}
+
+/**
  * Indicates that an unrecognized option was supplied.
  *
  * @property optName the name of the option

--- a/src/test/kotlin/com/xenomachina/argparser/ArgParserTest.kt
+++ b/src/test/kotlin/com/xenomachina/argparser/ArgParserTest.kt
@@ -1126,6 +1126,20 @@ This is the epilogue. Lorem ipsum dolor sit amet, consectetur adipiscing elit. D
         }
     }
 
+    test("Version") {
+        class Args(parser: ArgParser) {
+            val flag by parser.flagging(help = TEST_HELP)
+        }
+
+        shouldThrow<ShowVersionException> {
+            Args(parserOf("--version",
+                    version = "1.0.0")).flag
+        }.run {
+            val help = StringWriter().apply { printUserMessage(this, "program_name", 60) }.toString()
+            help shouldBe "1.0.0"
+        }
+    }
+
     test("Implicit long flag name") {
         class Args(parser: ArgParser) {
             val flag1 by parser.flagging(help = TEST_HELP)
@@ -1680,8 +1694,9 @@ class Circle : Shape()
 fun parserOf(
     vararg args: String,
     mode: ArgParser.Mode = ArgParser.Mode.GNU,
-    helpFormatter: HelpFormatter? = DefaultHelpFormatter()
-) = ArgParser(args, mode, helpFormatter)
+    helpFormatter: HelpFormatter? = DefaultHelpFormatter(),
+    version: String? = null
+) = ArgParser(args, mode, helpFormatter, version)
 
 /**
  * Helper function for getting the static (not runtime) type of an expression. This is useful for verifying that the


### PR DESCRIPTION
I've added a `--version` option in the same manner as the `--help` option.

The version can be provided in the ArgParser constructor if needed. If it is not provided, no `--version` option will be added. This makes the change fully compatible with older versions of the ArgParser.

I've also added a `-v` option for the version, but I'm unsure if this is wanted. Let me know, and I can remove it. 