### PR TITLE
Extend the optional delegate to accept a list of hardcoded acceptable values

### DIFF
--- a/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
@@ -266,7 +266,7 @@ class ArgParser(
     fun <T> option(
         vararg names: String,
         help: String,
-        errorName: String?,
+        errorName: String? = null,
         values: List<String>,
         transform: String.() -> T): Delegate<T> {
 

--- a/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
@@ -255,6 +255,43 @@ class ArgParser(
     }
 
     /**
+     * Creates a Delegate for an option with a list of hardcoded acceptable values
+     * @param names names of options, with leading "-" or "--"
+     * @param errorName name to use when talking about this option in error messages, or null to base it upon the
+     * option names
+     * @param help the help text for this option
+     * @param values the valid values the argument can have
+     * @param transform transforms the value after parsing
+     */
+    fun <T> option(
+        vararg names: String,
+        help: String,
+        errorName: String?,
+        values: List<String>,
+        transform: String.() -> T): Delegate<T> {
+
+        return option(
+            *names,
+            errorName = errorName,
+            help = help
+        ) {
+            if (!values.contains(arguments.first()))
+                throw SystemExitException("Invalid option '${arguments.first()}', valid options are: $values", -1)
+
+            transform(arguments.first())
+        }
+    }
+
+    /**
+     * Creates a Delegate for an optional with hardcoded acceptable values, which returns the argument's value
+     */
+    fun option(
+        vararg names: String,
+        errorName: String? = null,
+        values: List<String>,
+        help: String): Delegate<String> = option(*names, errorName = errorName, values = values, help = help) { this }
+
+    /**
      * Creates a Delegate for a single positional argument which returns the argument's value.
      */
     fun positional(name: String, help: String) = positional(name, help = help) { this }

--- a/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
@@ -270,9 +270,12 @@ class ArgParser(
         values: List<String>,
         transform: String.() -> T): Delegate<T> {
 
+        val nonNullArgName = optionNameToArgName(selectRepresentativeOptionName(names))
+
         return option(
             *names,
             errorName = errorName,
+            argNames = listOf(nonNullArgName),
             help = help
         ) {
             if (!values.contains(arguments.first()))


### PR DESCRIPTION
I propose to add the following overloads to the ArgParser@option function, so that we can specify a list of valid values, and if the user specifies anything else, it'll throw. Example usage would be

```kt
val mode by parser.option<Mode?>(
        "-m", "--mode",
        values = listOf("play", "search", "list"),
        help = "some very nice description, valid options are: [id, name, flags]",
    ) {
        when(this) {
            "play" -> Mode.Play
            "name" -> Mode.Search
            "tags" -> Mode.List
            else -> null
        }
    }.default(null)
```
or with the latter overload
```kt
val mode by parser.option(
        "-m", "--mode",
        values = listOf("play", "search", "list"),
        help = "some very nice description, valid options are: [play, search, list]",
    ).default<String?>(null)
```
This would allow usage to be as follows:
```bash
$ ./app --mode=play          // ok
$ ./app -m play              // ok
$ ./app -m hello             // error, "hello" was not a valid value
$ ./app                      // ok, the option has a default value and isnt a required field
```
It's technically already possible through the already existing overloads, but I can definitely see this to be a very common use, so
I find it valuable enough to be included in the library.
