### PR TITLE
A slightly more customizable implementation of HelpFormatter

### DIFF
--- a/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
@@ -615,7 +615,7 @@ class ArgParser(
         if (helpFormatter != null) {
             option<Unit>("-h", "--help",
                     errorName = "HELP", // This should never be used, but we need to say something
-                    help = "show this help message and exit") {
+                    help = helpFormatter.helpMessage) {
                 throw ShowHelpException(helpFormatter, delegates.toList())
             }.default(Unit).registerRoot()
         }

--- a/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/ArgParser.kt
@@ -615,7 +615,7 @@ class ArgParser(
         if (helpFormatter != null) {
             option<Unit>("-h", "--help",
                     errorName = "HELP", // This should never be used, but we need to say something
-                    help = helpFormatter.helpMessage) {
+                    help = helpFormatter.helpMessage) { //now this message is customizable
                 throw ShowHelpException(helpFormatter, delegates.toList())
             }.default(Unit).registerRoot()
         }

--- a/src/main/kotlin/com/xenomachina/argparser/DefaultHelpFormatter.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/DefaultHelpFormatter.kt
@@ -65,6 +65,8 @@ class DefaultHelpFormatter(
     val indent = "  "
     val indentWidth = indent.codePointWidth()
 
+	override value helpMessage = "show this help message and exit"
+
     override fun format(
         programName: String?,
         columns: Int,

--- a/src/main/kotlin/com/xenomachina/argparser/HelpFormatter.kt
+++ b/src/main/kotlin/com/xenomachina/argparser/HelpFormatter.kt
@@ -22,6 +22,11 @@ package com.xenomachina.argparser
  * Formats help for an [ArgParser].
  */
 interface HelpFormatter {
+
+	/**
+	 * The help message added automatically with the options -h, --help
+	 */  
+    val helpMessage: String
     /**
      * Formats a help message.
      *


### PR DESCRIPTION
Good morning,
first, I would like to compliment for this package. I am using it in my private projects and I am more than happy with it!
The reason of this pull request is an issue of customization. For reasons of internationalization and localization, I normally use ArgParser with a custom implementation of HelpFormatter. At the actual state, however, HelpFormatter has no control on the message "show this message and exit" automatically added with the options "-h, --help" to any ArgumentParsing. The edit I propose, instead, makes it possible for the implementation of HelpFormatter to customize this message. Since this message is printed only if ArgParser.helpFormatter is not null, it is safe to give it this responsibility.
Thank you for your consideration; I am always at disposal for further doubts and questions.